### PR TITLE
refactor: update ESLint configuration for unused variables and switch to TS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,7 @@
 !/.gitmodules
 
 # -------------------------------- Config files -------------------------------- #
-!/.eslintignore
-!/.eslintrc.js
-!/.eslintrc.ts.js
-!/index.js
-!/ts.js
+!/index.ts
 !/tsconfig.json
 
 # -------------------------------- Commitlint -------------------------------- #

--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,18 @@
 // @ts-check
 
-import eslintPluginUnicorn from 'eslint-plugin-unicorn';
+import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import globals from "globals";
-import pluginImportX from 'eslint-plugin-import-x'
-import pluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
-import stylistic from '@stylistic/eslint-plugin'
-import tseslint from 'typescript-eslint';
-import typescriptParser from '@typescript-eslint/parser';
+import pluginImportX from "eslint-plugin-import-x";
+import pluginSimpleImportSort from "eslint-plugin-simple-import-sort";
+import stylistic from "@stylistic/eslint-plugin";
+import tseslint from "typescript-eslint";
+import typescriptParser from "@typescript-eslint/parser";
 import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 import { globalIgnores } from "eslint/config";
+import { Linter } from "eslint";
 
-const nosFutursTsConfig = {
-  files: ['**/*.{ts,tsx}'],
+const nosFutursTsConfig: Linter.Config = {
+  files: ["**/*.{ts,tsx}"],
   languageOptions: {
     parser: typescriptParser,
     parserOptions: {
@@ -27,11 +28,11 @@ const nosFutursTsConfig = {
   },
   plugins: {
     import: pluginImportX,
-    'import-sort': pluginSimpleImportSort,
+    "import-sort": pluginSimpleImportSort,
   },
   settings: {
     // https://github.com/alexgorbatchev/eslint-import-resolver-typescript#configuration
-    'import-x/resolver-next': [
+    "import-x/resolver-next": [
       createTypeScriptImportResolver({
         alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
         bun: true, // resolve Bun modules https://github.com/import-js/eslint-import-resolver-typescript#bun
@@ -39,32 +40,41 @@ const nosFutursTsConfig = {
     ],
   },
   rules: {
-    '@typescript-eslint/explicit-function-return-type': 'warn', // Enforce explicit return types for functions
-    '@typescript-eslint/explicit-module-boundary-types': 'warn',
-    '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/no-explicit-any': 'warn',
-    '@stylistic/type-annotation-spacing': 'error', // Enforce consistent spacing before and after type annotations
-    "no-unused-vars": ["error", { "destructuredArrayIgnorePattern": "^_" }], // Ignore unused variables that are destructured from arrays
-    "@typescript-eslint/no-unused-vars": ["error", { "destructuredArrayIgnorePattern": "^_" }], // Ignore unused variables that are destructured from arrays
+    "@typescript-eslint/explicit-function-return-type": "warn", // Enforce explicit return types for functions
+    "@typescript-eslint/explicit-module-boundary-types": "warn",
+    "@typescript-eslint/interface-name-prefix": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@stylistic/type-annotation-spacing": "error", // Enforce consistent spacing before and after type annotations
+    // INFO: disable unused vars when using _ as a prefix
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+        ignoreRestSiblings: true,
+      },
+    ],
     // INFO: must disable the base rule as it can report incorrect errors. See https://typescript-eslint.io/rules/no-shadow/#how-to-use
-    'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': 'error',
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error",
     /* --------------------------------- Fastify -------------------------------- */
     // INFO: no-floating-promises requires all thenable to be handled, even when they are not real promises. Using the void qualifier  evaluates the expression then returns undefined. See https://github.com/fastify/fastify/discussions/3849 and https://github.com/typescript-eslint/typescript-eslint/issues/2640
-    'no-void': 'warn',
+    "no-void": "warn",
     /* --------------------------------- NestJS --------------------------------- */
     // INFO: Nest injects services in the empty constructors
-    'class-methods-use-this': 'off', // Enforce that class methods utilize 'this'.
-    'no-empty-function': 'warn', // Disallow empty functions.
-    'no-useless-constructor': 'warn', // Disallow unnecessary constructors.
+    "class-methods-use-this": "off", // Enforce that class methods utilize 'this'.
+    "no-empty-function": "warn", // Disallow empty functions.
+    "no-useless-constructor": "warn", // Disallow unnecessary constructors.
     /* ------------------------------ Import rules ------------------------------ */
-    'import/extensions': ['error', 'ignorePackages', { ts: 'never', '': 'never', }], // Prevent errors when importing TS packages. See https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md
-    'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*spec.ts', '**/*test.ts'], }], // Packages in test files should be in devDependencies, not normal dependencies
-    'import/prefer-default-export': 'warn', // Prefer default export over named exports when the file has a single export.
+    "import/extensions": ["error", "ignorePackages", { ts: "never", "": "never" }], // Prevent errors when importing TS packages. See https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md
+    "import/no-extraneous-dependencies": ["error", { devDependencies: ["**/*spec.ts", "**/*test.ts"] }], // Packages in test files should be in devDependencies, not normal dependencies
+    "import/prefer-default-export": "warn", // Prefer default export over named exports when the file has a single export.
     /* -------------------------- Import sorting rules -------------------------- */
-    'import/order': 'off', // Turn off ImportX order rule to use simple-import-sort plugin
-    'import-sort/exports': 'error',
-    'import-sort/imports': 'error',
+    "import/order": "off", // Turn off ImportX order rule to use simple-import-sort plugin
+    "import-sort/exports": "error",
+    "import-sort/imports": "error",
   },
 };
 
@@ -87,6 +97,3 @@ export default tseslint.config([
   eslintPluginUnicorn.configs.recommended,
   nosFutursTsConfig,
 ]);
-
-
-


### PR DESCRIPTION
- Disable the base rule for unused variables when using _ as a prefix.
- Enhance TypeScript ESLint rule to ignore arguments, variables, and caught errors with _ prefix, and allow ignoring rest siblings.
- Switch the js config file to ts 